### PR TITLE
Fixed incorrect shape for input_pack_kernel

### DIFF
--- a/conv_model_fwd.cpp
+++ b/conv_model_fwd.cpp
@@ -225,7 +225,7 @@ int conv_benchmark(int argc, char** argv) {
     if (pack_input == 0) {
       brgemm_kernel.gemm      = libxsmm_dispatch_brgemm_v2( l_shape, l_flags, l_prefetch_flags, l_brconfig );
     } else {
-      auto l_pack_shape = libxsmm_create_meltw_unary_shape(bc, gemm_n, bc*stride_w, bc, dtype, dtype, dtype);
+      auto l_pack_shape = libxsmm_create_meltw_unary_shape(bc, w_gemm_pixels, bc*stride_w, bc, dtype, dtype, dtype);
       input_pack_kernel = libxsmm_dispatch_meltw_unary_v2(LIBXSMM_MELTW_TYPE_UNARY_IDENTITY, l_pack_shape, LIBXSMM_MELTW_FLAG_UNARY_NONE);  
       l_shape = libxsmm_create_gemm_shape( gemm_m, gemm_n, gemm_k, bk, bc, bk, dtype, dtype, dtype, dtype );
       l_brconfig = libxsmm_create_gemm_batch_reduce_config( LIBXSMM_GEMM_BATCH_REDUCE_STRIDE, R*S*bc*bk*sizeof(DType), bc*ofh*ofw*sizeof(DType), Cb_step );   


### PR DESCRIPTION
Fixed incorrect shape for input_pack_kernel (was going too far in memory due to wrong h_in_gemm treatment)

Details:
Currently input_pack_shape has `m ~ gemm_n ~ w_gemm_pixels * h_in_gemm`, while due to the loop over _h where we call TPP for packing, we actually (rightfully) go over each h-line, and hence we should have had `m ~ w_gemm_pixels` (with `w_gemm_pixels ~ ofw/w_block ~ ofw ~ ifw/stride in this case`).

It matters for strided 1x1 convolutions with pack_input = 1 and h_in_gemm > 1.

Debugged on the case:
USE_BF16=1 ./conv_fwd "Afgbdec" N 28 28 512 1024 1 1 2 2 0 0 32 32 1 1 1 1 2 1 100

The result is that currently we go over the allocated memory and while it is not seen in the standalone runs, other codes (fused Resnet bottlenecks in PCL PT extensions) crash.