### PR TITLE
Fix LIBXSMM_ROOT in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Further information: https://github.com/libxsmm/libxsmm/                    #
 # SPDX-License-Identifier: BSD-3-Clause                                       #
 ###############################################################################
-LIBXSMM_ROOT := $(if $(LIBXSMM_ROOT),$(LIBXSMM_ROOT),./)
+LIBXSMM_ROOT := $(if $(LIBXSMM_ROOT),$(LIBXSMM_ROOT),./libxsmm/)
 
 CXXFLAGS = -fopenmp -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++14 -O2 
 LDFLAGS = -ldl -lxsmm -lxsmmnoblas


### PR DESCRIPTION
If user doesn't specify LIBXSMM_ROOT after prepare_libxsmm.sh.
LIBXSMM_ROOT should be pointed to libxsmm in current directory.

Signed-off-by: Jincheng Miao <jincheng.miao@intel.com>