### PR TITLE
Fixing conv_model_bwd validation (plus increasing verbosity for conv fwd and bwd)

### DIFF
--- a/conv_model_bwd.cpp
+++ b/conv_model_bwd.cpp
@@ -348,8 +348,6 @@ int conv_benchmark(int argc, char** argv) {
                       (ii < pad_w_in || ii >= ifw + pad_w_in)) {
                     libxsmm_meltw_unary_param zero_param;
                     zero_param.out.primary = LIBXSMM_ACCESS_RAW(5, sizeof(DType), input_libxsmm, i_n, i_c, ij, ii, 0, Cb, ifhp, ifwp, bc);
-                    //for (int k = 0; k < bc; k++)
-                    //  ((libxsmm_bfloat16*)zero_param.out.primary)[k] = 0;
                     zero_kernel_bc( &zero_param );
                   }
                 }

--- a/conv_model_bwd.cpp
+++ b/conv_model_bwd.cpp
@@ -172,7 +172,7 @@ int conv_benchmark(int argc, char** argv) {
     non_1x1_with_strides = 1;
   }
 
-  printf("Algorithm decisions: avoid_rim_fmas non_1x1_with-strides: %d %d \n", avoid_rim_fmas, non_1x1_with_strides);
+  printf("Algorithm decisions: avoid_rim_fmas non_1x1_with_strides: %d %d \n", avoid_rim_fmas, non_1x1_with_strides);
 
   if ((R == 1 && S == 1) ||
       (avoid_rim_fmas == 1) ||
@@ -414,6 +414,10 @@ int conv_benchmark(int argc, char** argv) {
       tensor_copy_NCHWc_to_NCHW (naive_input_nchwc, naive_input_opt, N, C, ifhp, ifwp, bc);
     } else {
       tensor_copy_NCHWc_to_NCHW ((float*)input_libxsmm, naive_input_opt, N, C, ifhp, ifwp, bc);
+    }
+    /* If non 1x1 and multiple h in gemm, then make sure that we zero out the rims... */
+    if ((R != 1 || S != 1) && (h_in_gemm > 1)) {
+      set_zeropad_nchw(naive_input_opt, N, C, ifhp, ifwp, pad_h_in, pad_w_in);
     }
     printf("##########################################\n");
     printf("#           Correctness - BWD            #\n");

--- a/conv_model_bwd.cpp
+++ b/conv_model_bwd.cpp
@@ -445,7 +445,7 @@ int conv_benchmark(int argc, char** argv) {
   // Print performance/model numbers
   double gflop = (2.0*(double)n_iters*(double)N*(double)C*(double)K*(double)R*(double)S*(double)ofh*(double)ofw)/(1000*1000*1000);
   //printf("Compilation time is %.5g s\n", t1-t0);
-  printf("GFLOPS %.6g %s_hb=%d_wb=%d_cb=%d_kb=%d\n", gflop/(t_end-t_start), loop_specs_str, h_block, w_block, c_block, k_block);
+  printf("GFLOPS %.6g %s_hb=%d_wb=%d_cb=%d_kb=%d_hg=%d\n", gflop/(t_end-t_start), loop_specs_str, h_block, w_block, c_block, k_block, h_in_gemm);
 
   // Free buffers
   libxsmm_free(naive_input);

--- a/conv_model_fwd.cpp
+++ b/conv_model_fwd.cpp
@@ -60,6 +60,9 @@ int conv_benchmark(int argc, char** argv) {
     }
   }
   
+  printf("Test parameters: N H W C K R S stride_h stride_w pad_h pad_w bc bk: %d %d %d %d %d %d %d %d %d %d %d %d %d \n", N, H, W, C, K, R, S, stride_h, stride_w, pad_h, pad_w, bc, bk);
+  printf("Tuning parameters: h_block w_block c_block k_block h_in_gemm pack_input: %d %d %d %d %d %d\n", h_block, w_block, c_block, k_block, h_in_gemm, pack_input);
+
   if (c_block == 1 && loop_specs_str[3] != 'b' ) {
     //return 0;
   }
@@ -369,7 +372,7 @@ int conv_benchmark(int argc, char** argv) {
   // Print performance/model numbers
   double gflop = (2.0*(double)n_iters*(double)N*(double)C*(double)K*(double)R*(double)S*(double)ofh*(double)ofw)/(1000*1000*1000);
   //printf("Compilation time is %.5g s\n", t1-t0);
-  printf("GFLOPS %.6g %s_hb=%d_wb=%d_cb=%d_kb=%d\n", gflop/((double)(t_end-t_start)), loop_specs_str, h_block, w_block, c_block, k_block);
+  printf("GFLOPS %.6g %s_hb=%d_wb=%d_cb=%d_kb=%d_hg=%d_pu=%d\n", gflop/((double)(t_end-t_start)), loop_specs_str, h_block, w_block, c_block, k_block, h_in_gemm, pack_input);
   printf("PERFDUMP,FP,%s,%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%.5g,%.5g,%f,%f,%f,%f,%f,%f,%f\n", LIBXSMM_VERSION, omp_get_max_threads(), N, C, K,
         H, W, R, S, stride_h, pad_h, pad_w, ((double)((t_end - t_start)/n_iters)), (gflop)/(t_end - t_start), norms.l1_ref, norms.l1_tst,
         norms.l2_abs, norms.l2_rel, norms.linf_abs, norms.linf_rel, norms.normf_rel);

--- a/test_conv_bwd.sh
+++ b/test_conv_bwd.sh
@@ -18,7 +18,6 @@ k_block=1
 h_in_gemm=1
 
 # 52 convolutions from Resnet50-v1.5
-: '
 ./conv_bwd "${loop_string}" $N 56 56 64 64      1 1 1 1 0 0 $bc $bk $h_block $w_block $c_block $k_block $h_in_gemm $niters
 ./conv_bwd "${loop_string}" $N 56 56 64 256     1 1 1 1 0 0 $bc $bk $h_block $w_block $c_block $k_block $h_in_gemm $niters
 ./conv_bwd "${loop_string}" $N 56 56 64 256     1 1 1 1 0 0 $bc $bk $h_block $w_block $c_block $k_block $h_in_gemm $niters
@@ -132,7 +131,7 @@ h_in_gemm=2
 # These two should early exit as strided convs do not support h_in_gemm != 1
 ./conv_bwd "${loop_string}" $N  14 14 1024 2048 1 1 2 2 0 0 $bc $bk $h_block $w_block $c_block $k_block $h_in_gemm $niters
 ./conv_bwd "${loop_string}" $N  14 14 512 512   3 3 2 2 1 1 $bc $bk $h_block $w_block $c_block $k_block $h_in_gemm $niters
-'
+
 h_block=1
 w_block=1
 c_block=1
@@ -147,6 +146,13 @@ k_block=1
 h_in_gemm=1
 ./conv_bwd "${loop_string}" $N  14 14 1024 2048 1 1 2 2 0 0 $bc $bk $h_block $w_block $c_block $k_block $h_in_gemm $niters
 ./conv_bwd "${loop_string}" $N  14 14 512 512   3 3 2 2 1 1 $bc $bk $h_block $w_block $c_block $k_block $h_in_gemm $niters
+
+h_block=1
+w_block=1
+c_block=1
+k_block=1
+h_in_gemm=2
+./conv_bwd "${loop_string}" $N 14 14 256 256  3 3  1 1  1 1 $bc $bk $h_block $w_block $c_block $k_block $h_in_gemm $niters
 
 #./conv_bwd $@
 #export OMP_NUM_THREADS=28


### PR DESCRIPTION
Not really a bug in the conv code but rather a missing piece in the driver for the case h_in_gemm > 1 (missing was zeroing the padded part prior to checking for accuracy)