### PR TITLE
Adding support for 7x7 (s1, s2) filters and 3x3 s2 (and 1x1 s2) convolutions when avoiding rim fmas

### DIFF
--- a/conv_model_fwd.cpp
+++ b/conv_model_fwd.cpp
@@ -254,7 +254,6 @@ int conv_benchmark(int argc, char** argv) {
 
   // JIT requested nested loop specs
 
-
   auto t0 = getTime();
   auto conv_loop = ThreadedLoop<7>({
       LoopSpecs{0, N, n_step, true},
@@ -321,13 +320,16 @@ int conv_benchmark(int argc, char** argv) {
           }
           if (i_r == 0 && i_h == 0) {
             /* Do no FLOPS  */
-          } else if (i_r == R-1 && i_h == ofh-1 ) {
+          //} else if (i_r == R-1 && i_h == ofh-1 ) {
+          } else if (i_r == R-1 && (i_h + h_step - 1)*stride_h + i_r == ifh + 1 ) {
             /* Do no FLOPS  */
           } else if ( i_w == 0 && i_s == 0 ) {
-            gemm_param.b.primary = LIBXSMM_ACCESS_RAW(5, sizeof(DType), input_libxsmm, i_n, i_c, i_h * stride_h + i_r, i_w * stride_w + i_s + 1, 0, Cb, ifhp, ifwp, bc);
+            //gemm_param.b.primary = LIBXSMM_ACCESS_RAW(5, sizeof(DType), input_libxsmm, i_n, i_c, i_h * stride_h + i_r, i_w * stride_w + i_s + 1, 0, Cb, ifhp, ifwp, bc);
+            gemm_param.b.primary = LIBXSMM_ACCESS_RAW(5, sizeof(DType), input_libxsmm, i_n, i_c, i_h * stride_h + i_r, (i_w + 1) * stride_w + i_s, 0, Cb, ifhp, ifwp, bc);
             gemm_param.c.primary = LIBXSMM_ACCESS_RAW(5, sizeof(DType), output_libxsmm_off, i_n, i_k, i_h, i_w + 1, 0, Kb, ofhp, ofwp, bk);       
             brgemm_kernel2.gemm( &gemm_param );
-          } else if ( i_w + w_step == ofw  && i_s == S-1) {
+          //} else if ( i_w + w_step == ofw  && i_s == S-1) {
+          } else if ( (i_w + w_step - 1)*stride_w + i_s == ifw + 1 && i_s == S-1) {
             gemm_param.b.primary = LIBXSMM_ACCESS_RAW(5, sizeof(DType), input_libxsmm, i_n, i_c, i_h * stride_h + i_r, i_w * stride_w + i_s, 0, Cb, ifhp, ifwp, bc);
             gemm_param.c.primary = LIBXSMM_ACCESS_RAW(5, sizeof(DType), output_libxsmm_off, i_n, i_k, i_h, i_w, 0, Kb, ofhp, ofwp, bk);
             brgemm_kernel2.gemm( &gemm_param );


### PR DESCRIPTION
Currently avoid_rim_fmas only gets enabled for 7x7 3x3 s1 convolutions (from all resnet bottleneck layers)

Tested locally on:
./conv_fwd.sh Afgbdced 56 56 56 128 128 3 3 1 1 1 1 64 64 1 1 1 1 1 0 10 # this one should have worked always
./conv_fwd.sh Afgbdced 56 56 56 128 128 3 3 2 2 1 1 64 64 1 1 1 1 1 0 10
./conv_fwd.sh Afgbdced 56 224 224 4 64 7 7 2 2 3 3 4 64 1 1 1 1 1 0 10
./conv_fwd.sh Afgbdced 56 56 56 256 512 1 1 2 2 0 0 64 64 4 1 1 1 1 0 10
with locally (not in the PR) enabled avoid_rim_fmas = 1.