### PR TITLE
Changed multiple_target to 32 for bf16 conv upd

### DIFF
--- a/conv_model_upd.cpp
+++ b/conv_model_upd.cpp
@@ -54,7 +54,7 @@ int conv_benchmark(int argc, char** argv) {
   long n_img_teams = 7;
   long n_ofm_teams = 4;
   long weight_copies = 0;
-  long multiple_target = 2;
+  long multiple_target = (sizeof(DType) == 2 ? 32 : 2);
   long max_compute_offset_input = 0;
   long use_f32_wt_reduction_and_external_wt_vnni = 0;
   long compute_full_wt_output_block = 0;
@@ -468,7 +468,7 @@ int conv_benchmark(int argc, char** argv) {
   printf("Tuning parameters: use_hybrid n_img_teams n_ofm_teams: %d %d %d \n", use_hybrid_imgfm_parallelization, n_img_teams, n_ofm_teams);
   printf("Tuning parameters: use_f32_wt_reduction_and_external_wt_vnni compute_full_wt_output_block pblock: %d %d %d \n", use_f32_wt_reduction_and_external_wt_vnni, compute_full_wt_output_block, pixels_blocking_factor);
   printf("Tuning parameters: use_mb_par_f32: %d \n", use_mb_par_f32);
-
+  printf("Inferred parameters: multiple_target: %d \n", multiple_target);
 
   auto t0 = getTime();
 


### PR DESCRIPTION
One-liner change but better to have it as a separate commit than hide in some other set of changes.

Rationale: this change improves (w.r.t to multiple_target = 2) performance for bf16 conv upd for cases like
./conv_upd A{R:56}C{C:1}dbef 56 28 28 128 128 3 3 1 1 1 1 32 32 1000 1 0 0 0 0 1 1 56 1 0 0 1
./conv_upd A{R:56}C{C:1}dbef 56 14 14 256 256 3 3 1 1 1 1 32 32 1000 1 0 0 0 0 1 1 56 1 0 0 1
./conv_upd A{R:56}C{C:1}dbef 56 56 56 64 64 3 3 1 1 1 1 32 32 1000 1 0 0 0 0 1 1 56 1 0 0 1