### PR TITLE
Updated conv fwd/bwd/upd to work with new version libxsmm_dnn (upd is still incorrect on ARM though)

### DIFF
--- a/conv_model_fwd.cpp
+++ b/conv_model_fwd.cpp
@@ -128,7 +128,7 @@ int conv_benchmark(int argc, char** argv) {
   if (sizeof(DType) == 2) {
     tensor_copy_NCHW_to_NCHWc (naive_input , naive_input_nchwc,  N, C, ifhp, ifwp, bc);
     tensor_copy_NCHW_to_NCHWc (naive_output, naive_output_nchwc, N, K, ofhp, ofwp, bk);
-    tensor_copy_KCRS_to_KCRSck_bf16(naive_filter, (libxsmm_bfloat16*)filter_libxsmm, K, C, R, S, bc, bk);
+    tensor_cvt_copy_KCRS_to_KCRSck_bf16(naive_filter, (libxsmm_bfloat16*)filter_libxsmm, K, C, R, S, bc, bk);
     libxsmm_rne_convert_fp32_bf16( naive_input_nchwc,     (libxsmm_bfloat16*)input_libxsmm,     N*C*ifhp*ifwp );
     libxsmm_rne_convert_fp32_bf16( naive_output_nchwc,    (libxsmm_bfloat16*)output_libxsmm,    N*K*ofhp*ofwp );
     //libxsmm_rne_convert_fp32_bf16( naive_filter_kcrsck,   (libxsmm_bfloat16*)filter_libxsmm,    K*C*R*S );

--- a/conv_model_upd.cpp
+++ b/conv_model_upd.cpp
@@ -194,7 +194,7 @@ int conv_benchmark(int argc, char** argv) {
   if (sizeof(DType) == 2) {
     tensor_copy_NCHW_to_NCHWc (naive_input , naive_input_nchwc,  N, C, ifhp, ifwp, bc);
     tensor_copy_NCHW_to_NCHWc (naive_output, naive_output_nchwc, N, K, ofhp, ofwp, bk);
-    tensor_copy_KCRS_to_KCRSck_bf16(naive_filter, (libxsmm_bfloat16*)filter_libxsmm, K, C, R, S, bc, bk);
+    tensor_cvt_copy_KCRS_to_KCRSck_bf16(naive_filter, (libxsmm_bfloat16*)filter_libxsmm, K, C, R, S, bc, bk);
     libxsmm_rne_convert_fp32_bf16( naive_input_nchwc,     (libxsmm_bfloat16*)input_libxsmm,     N*C*ifhp*ifwp );
     libxsmm_rne_convert_fp32_bf16( naive_output_nchwc,    (libxsmm_bfloat16*)output_libxsmm,    N*K*ofhp*ofwp );
   } else {
@@ -1043,7 +1043,7 @@ int conv_benchmark(int argc, char** argv) {
   // Check correctness if requested
   if (check_correctness) {
     if (sizeof(DType) == 2) {
-      tensor_copy_KCRSck_vnni_to_norm_f32( (libxsmm_bfloat16*)filter_libxsmm, naive_filter_kcrsck, K, C, R, S, bc, bk);
+      tensor_cvt_copy_KCRSck_vnni_to_norm_f32( (libxsmm_bfloat16*)filter_libxsmm, naive_filter_kcrsck, K, C, R, S, bc, bk);
       tensor_copy_KCRSck_to_KCRS( (float*)naive_filter_kcrsck, naive_filter_opt, K, C, R, S, bc, bk);
     } else {
       tensor_copy_KCRSck_to_KCRS( (float*)filter_libxsmm, naive_filter_opt, K, C, R, S, bc, bk);


### PR DESCRIPTION
Updated the names of utility routines used from dnn_common.h header (from libxsmm-dnn) in conv_model_fwd/bwd/upd.cpp

Without the changes, these codes cannot be compiled successfully.

Note: this PR should go in after https://github.com/libxsmm/libxsmm-dnn/pull/8 PR is merged into libxsmm-dnn.