### PR TITLE
Switched to BCAST_COL_IN_0 for bias in conv fwd (as a more performant version potentially)

### DIFF
--- a/samples/conv/conv_model_fwd.cpp
+++ b/samples/conv/conv_model_fwd.cpp
@@ -342,7 +342,7 @@ int conv_benchmark(int argc, char** argv) {
 
     if (with_bias) {
       auto l_binary_shape = libxsmm_create_meltw_binary_shape(bk, w_gemm_pixels, bk, bk, bk, dtype, dtype, dtype, LIBXSMM_DATATYPE_F32);
-      colbias_add_kernel = libxsmm_dispatch_meltw_binary_v2( LIBXSMM_MELTW_TYPE_BINARY_ADD, l_binary_shape, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_1);
+      colbias_add_kernel = libxsmm_dispatch_meltw_binary_v2( LIBXSMM_MELTW_TYPE_BINARY_ADD, l_binary_shape, LIBXSMM_MELTW_FLAG_BINARY_BCAST_COL_IN_0);
     }
     if (with_relu) {
 #ifdef __x86_64__
@@ -644,9 +644,9 @@ int conv_benchmark(int argc, char** argv) {
           if ((with_bias || with_relu) && i_r == R - r_step && i_s == S - s_step && i_c == Cb - c_step) {
             if (with_bias) {
               libxsmm_meltw_binary_param binary_param;
-              binary_param.in0.primary = (void*)LIBXSMM_ACCESS_RAW(5, sizeof(DType), output_libxsmm_off, i_n, i_k, i_h, i_w, 0, Kb, ofhp, ofwp, bk);
-              binary_param.in1.primary = (void*)LIBXSMM_ACCESS_RAW(2, sizeof(DType), bias_libxsmm, i_k, 0, bk);
-              binary_param.out.primary = binary_param.in0.primary;
+              binary_param.in0.primary = (void*)LIBXSMM_ACCESS_RAW(2, sizeof(DType), bias_libxsmm, i_k, 0, bk);
+              binary_param.in1.primary = (void*)LIBXSMM_ACCESS_RAW(5, sizeof(DType), output_libxsmm_off, i_n, i_k, i_h, i_w, 0, Kb, ofhp, ofwp, bk);
+              binary_param.out.primary = binary_param.in1.primary;
               colbias_add_kernel( &binary_param );
             }
             if (with_relu) {


### PR DESCRIPTION
Rationale: better code will be generated (even if no real performance gains on resnet-50 topology).

Tested with: 
OMP_NUM_THREADS=16 USE_BF16=1 ./conv_fwd A{C:4}C{R:4}fgbde   16 7 7 512 512 3 3   1 1 1 1  32 32   1 1 1 1 1 0  $niters 0 0  1 1 1 1  1 1  0 # which should go into the changed path avoid_rim_fmas = 1