### PR TITLE
Adding a global makefile to create parlooper static and dynamic libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,9 @@ $(BLDDIR)/%-cpp.o: %.cpp
 	$(CXX) -fPIC $(CXXFLAGS) $(IFLAGS) $(LFLAGS)  -c $< -o $@ $(LDFLAGS)
 
 CLEANOBJ:
-	rm -rf $(BLDDIR)/*.o
+	rm -f $(BLDDIR)/*.o
 
 .PHONY: clean
-clean:
-	rm -rf $(LIBDIR)/*.a $(LIBDIR)/*.so $(BLDDIR)/*.o
+clean: CLEANOBJ
+	rm -f $(LIBDIR)/*.a $(LIBDIR)/*.so
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+###############################################################################
+# Copyright (c) Intel Corporation - All rights reserved.                      #
+# This file is part of the LIBXSMM library.                                   #
+#                                                                             #
+# For information on the license, see the LICENSE file.                       #
+# Further information: https://github.com/libxsmm/libxsmm/                    #
+# SPDX-License-Identifier: BSD-3-Clause                                       #
+###############################################################################
+BLDDIR := $(if $(BLDDIR),$(BLDDIR),./build)
+LIBDIR := $(if $(LIBDIR),$(LIBDIR),./lib)
+LIBXSMM_ROOT := $(if $(LIBXSMM_ROOT),$(LIBXSMM_ROOT),../../libxsmm)
+LIBXSMM_DNN_ROOT := $(if $(LIBXSMM_DNN_ROOT),$(LIBXSMM_DNN_ROOT),../../libxsmm_dnn)
+CXX = g++
+CXXFLAGS = -fopenmp -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++14 -O2
+ifeq ($(PARLOOPER_COMPILER),gcc)
+  CXX := g++
+  CXXFLAGS := -fopenmp -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++14 -O2
+endif
+ifeq ($(PARLOOPER_COMPILER),clang)
+  CXX := clang++
+  CXXFLAGS := -Wno-unused-command-line-argument -Wno-format -fopenmp=libomp -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++14 -O2  
+endif
+ifeq ($(PARLOOPER_COMPILER),icc)
+  CXX := icpc
+  CXXFLAGS := -fopenmp -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++14 -O2 
+endif
+LDFLAGS = -ldl 
+IFLAGS = -I./include -I./utils -I$(LIBXSMM_ROOT)/include -I$(LIBXSMM_DNN_ROOT)/include
+SRCDIRS = ./utils ./src .
+SRCFILES := jit_compile.cpp par_loop_generator.cpp
+OBJFILES := $(patsubst %,$(BLDDIR)/%,$(notdir $(SRCFILES:.cpp=-cpp.o)))
+vpath %.cpp $(SRCDIRS) 
+
+$(info "BLDDIR = $(BLDDIR)")
+$(info "OBJFILES = $(OBJFILES)")
+
+.PHONY: all
+all: builddir libdir slib dlib CLEANOBJ
+
+builddir:
+	mkdir -p $(BLDDIR)
+
+libdir:
+	mkdir -p $(LIBDIR)
+
+slib: libdir $(OBJFILES)
+	ar rcs $(LIBDIR)/libparlooper.a $(OBJFILES)
+
+dlib: libdir $(OBJFILES)
+	$(CXX) -o $(LIBDIR)/libparlooper.so $(OBJFILES) -shared
+
+$(BLDDIR)/%-cpp.o: %.cpp
+	$(CXX) -fPIC $(CXXFLAGS) $(IFLAGS) $(LFLAGS)  -c $< -o $@ $(LDFLAGS)
+
+CLEANOBJ:
+	rm -rf $(BLDDIR)/*.o
+
+.PHONY: clean
+clean:
+	rm -rf $(LIBDIR)/*.a $(LIBDIR)/*.so $(BLDDIR)/*.o
+

--- a/samples/conv/Makefile
+++ b/samples/conv/Makefile
@@ -28,8 +28,8 @@ endif
 LDFLAGS = -ldl 
 IFLAGS = -I$(PARLOOPER_ROOT)/include -I$(PARLOOPER_ROOT)/utils -I$(LIBXSMM_ROOT)/include -I$(LIBXSMM_DNN_ROOT)/include
 SRCDIRS = $(PARLOOPER_ROOT)/utils $(PARLOOPER_ROOT)/src .
-SRCFILES := common_loops.cpp par_loop_cost_estimator.cpp
-OBJFILES := $(patsubst %,$(BLDDIR)/%,$(notdir $(SRCFILES:.cpp=-cpp.o)))
+#SRCFILES := common_loops.cpp par_loop_cost_estimator.cpp
+#OBJFILES := $(patsubst %,$(BLDDIR)/%,$(notdir $(SRCFILES:.cpp=-cpp.o)))
 XFILES := $(OUTDIR)/conv_fwd $(OUTDIR)/conv_bwd $(OUTDIR)/conv_upd $(OUTDIR)/loop_permute_generator
 vpath %.cpp $(SRCDIRS) 
 
@@ -54,9 +54,9 @@ $(OUTDIR)/loop_permute_generator:
 	$(CXX) $(CXXFLAGS) $(PARLOOPER_ROOT)/utils/spec_loop_generator.cpp -o loop_permute_generator
 
 CLEANOBJ:
-	rm -rf *.o
+	rm -f *.o $(BLDDIR)/*.o
 
 .PHONY: clean
-clean:
-	rm -rf conv_fwd conv_bwd conv_upd loop_permute_generator *.o
+clean: CLEANOBJ
+	rm -f $(XFILES)
 

--- a/samples/conv/Makefile
+++ b/samples/conv/Makefile
@@ -7,6 +7,8 @@
 # SPDX-License-Identifier: BSD-3-Clause                                       #
 ###############################################################################
 BLDDIR = .
+OUTDIR = .
+PARLOOPER_ROOT := $(if $(PARLOOPER_ROOT),$(PARLOOPER_ROOT),../../)
 LIBXSMM_ROOT := $(if $(LIBXSMM_ROOT),$(LIBXSMM_ROOT),../../libxsmm)
 LIBXSMM_DNN_ROOT := $(if $(LIBXSMM_DNN_ROOT),$(LIBXSMM_DNN_ROOT),../../libxsmm_dnn)
 CXX = g++
@@ -24,9 +26,9 @@ ifeq ($(PARLOOPER_COMPILER),icc)
   CXXFLAGS := -fopenmp -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++14 -O2 
 endif
 LDFLAGS = -ldl 
-IFLAGS = -I../../include -I../../utils -I$(LIBXSMM_ROOT)/include -I$(LIBXSMM_DNN_ROOT)/include
-SRCDIRS = ../../utils ../../src .
-SRCFILES := par_loop_cost_estimator.cpp par_loop_generator.cpp jit_compile.cpp common_loops.cpp 
+IFLAGS = -I$(PARLOOPER_ROOT)/include -I$(PARLOOPER_ROOT)/utils -I$(LIBXSMM_ROOT)/include -I$(LIBXSMM_DNN_ROOT)/include
+SRCDIRS = $(PARLOOPER_ROOT)/utils $(PARLOOPER_ROOT)/src .
+SRCFILES := common_loops.cpp par_loop_cost_estimator.cpp
 OBJFILES := $(patsubst %,$(BLDDIR)/%,$(notdir $(SRCFILES:.cpp=-cpp.o)))
 XFILES := $(OUTDIR)/conv_fwd $(OUTDIR)/conv_bwd $(OUTDIR)/conv_upd $(OUTDIR)/loop_permute_generator
 vpath %.cpp $(SRCDIRS) 
@@ -37,17 +39,19 @@ all: $(XFILES) CLEANOBJ
 $(BLDDIR)/%-cpp.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -c $< -o $@
 
-$(OUTDIR)/conv_fwd: $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_fwd-cpp.o
-	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_fwd-cpp.o $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o conv_fwd
+#$(OUTDIR)/conv_fwd: $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_fwd-cpp.o
+#	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_fwd-cpp.o $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o conv_fwd
+$(OUTDIR)/conv_fwd: $(BLDDIR)/par_loop_cost_estimator-cpp.o $(BLDDIR)/common_loops-cpp.o $(BLDDIR)/conv_model_fwd-cpp.o
+	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_fwd-cpp.o $(PARLOOPER_ROOT)/lib/libparlooper.a $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o conv_fwd
 
-$(OUTDIR)/conv_bwd: $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_bwd-cpp.o
-	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_bwd-cpp.o $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o conv_bwd
+$(OUTDIR)/conv_bwd: $(BLDDIR)/par_loop_cost_estimator-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_bwd-cpp.o
+	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_bwd-cpp.o $(PARLOOPER_ROOT)/lib/libparlooper.a $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o conv_bwd
 
-$(OUTDIR)/conv_upd: $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_upd-cpp.o
-	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_upd-cpp.o $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o conv_upd
+$(OUTDIR)/conv_upd: $(BLDDIR)/par_loop_cost_estimator-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_upd-cpp.o
+	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/conv_model_upd-cpp.o $(PARLOOPER_ROOT)/lib/libparlooper.a $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o conv_upd
 
 $(OUTDIR)/loop_permute_generator:
-	$(CXX) $(CXXFLAGS) ../../utils/spec_loop_generator.cpp -o loop_permute_generator
+	$(CXX) $(CXXFLAGS) $(PARLOOPER_ROOT)/utils/spec_loop_generator.cpp -o loop_permute_generator
 
 CLEANOBJ:
 	rm -rf *.o

--- a/samples/gemm/Makefile
+++ b/samples/gemm/Makefile
@@ -7,6 +7,8 @@
 # SPDX-License-Identifier: BSD-3-Clause                                       #
 ###############################################################################
 BLDDIR = .
+OUTDIR = .
+PARLOOPER_ROOT := $(if $(PARLOOPER_ROOT),$(PARLOOPER_ROOT),../../)
 LIBXSMM_ROOT := $(if $(LIBXSMM_ROOT),$(LIBXSMM_ROOT),../../libxsmm)
 LIBXSMM_DNN_ROOT := $(if $(LIBXSMM_DNN_ROOT),$(LIBXSMM_DNN_ROOT),../../libxsmm_dnn)
 CXX = g++
@@ -24,10 +26,10 @@ ifeq ($(PARLOOPER_COMPILER),icc)
   CXXFLAGS := -fopenmp -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++14 -O2 
 endif
 LDFLAGS = -ldl 
-IFLAGS = -I../../include -I../../utils -I$(LIBXSMM_ROOT)/include -I$(LIBXSMM_DNN_ROOT)/include
-SRCDIRS = ../../utils ../../src .
-SRCFILES := par_loop_cost_estimator.cpp par_loop_generator.cpp jit_compile.cpp common_loops.cpp gemm_model_fwd.cpp
-OBJFILES := $(patsubst %,$(BLDDIR)/%,$(notdir $(SRCFILES:.cpp=-cpp.o)))
+IFLAGS = -I$(PARLOOPER_ROOT)/include -I$(PARLOOPER_ROOT)/utils -I$(LIBXSMM_ROOT)/include -I$(LIBXSMM_DNN_ROOT)/include
+SRCDIRS = $(PARLOOPER_ROOT)/utils $(PARLOOPER_ROOT)/src .
+#SRCFILES := par_loop_cost_estimator.cpp common_loops.cpp gemm_model_fwd.cpp
+#OBJFILES := $(patsubst %,$(BLDDIR)/%,$(notdir $(SRCFILES:.cpp=-cpp.o)))
 XFILES := $(OUTDIR)/gemm $(OUTDIR)/gemm_bwd $(OUTDIR)/gemm_upd $(OUTDIR)/loop_permute_generator
 vpath %.cpp $(SRCDIRS) 
 
@@ -37,22 +39,22 @@ all: $(XFILES) CLEANOBJ
 $(BLDDIR)/%-cpp.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -c $< -o $@
 
-$(OUTDIR)/gemm: $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_fwd-cpp.o
-	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_fwd-cpp.o $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o gemm
+$(OUTDIR)/gemm: $(BLDDIR)/par_loop_cost_estimator-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_fwd-cpp.o
+	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_fwd-cpp.o $(PARLOOPER_ROOT)/lib/libparlooper.a $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o gemm
 
-$(OUTDIR)/gemm_bwd: $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_bwd-cpp.o
-	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_bwd-cpp.o $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o gemm_bwd
+$(OUTDIR)/gemm_bwd: $(BLDDIR)/par_loop_cost_estimator-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_bwd-cpp.o
+	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_bwd-cpp.o $(PARLOOPER_ROOT)/lib/libparlooper.a $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o gemm_bwd
 
-$(OUTDIR)/gemm_upd: $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_upd-cpp.o
-	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_upd-cpp.o $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o gemm_upd
+$(OUTDIR)/gemm_upd: $(BLDDIR)/par_loop_cost_estimator-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_upd-cpp.o
+	$(CXX) $(BLDDIR)/par_loop_cost_estimator-cpp.o  $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/gemm_model_upd-cpp.o $(PARLOOPER_ROOT)/lib/libparlooper.a $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o gemm_upd
 
 $(OUTDIR)/loop_permute_generator:
-	$(CXX) $(CXXFLAGS) ../../utils/spec_loop_generator.cpp -o loop_permute_generator
+	$(CXX) $(CXXFLAGS) $(PARLOOPER_ROOT)/utils/spec_loop_generator.cpp -o loop_permute_generator
 
 CLEANOBJ:
-	rm -rf *.o
+	rm -f *.o $(BLDDIR)/*.o
 
 .PHONY: clean
-clean:
-	rm -rf gemm gemm_bwd gemm_upd loop_permute_generator *.o
+clean: CLEANOBJ
+	rm -f $(XFILES)
 

--- a/samples/spgemm/Makefile
+++ b/samples/spgemm/Makefile
@@ -7,6 +7,8 @@
 # SPDX-License-Identifier: BSD-3-Clause                                       #
 ###############################################################################
 BLDDIR = .
+OUTDIR = .
+PARLOOPER_ROOT := $(if $(PARLOOPER_ROOT),$(PARLOOPER_ROOT),../../)
 LIBXSMM_ROOT := $(if $(LIBXSMM_ROOT),$(LIBXSMM_ROOT),../../libxsmm)
 LIBXSMM_DNN_ROOT := $(if $(LIBXSMM_DNN_ROOT),$(LIBXSMM_DNN_ROOT),../../libxsmm_dnn)
 CXX = g++
@@ -24,10 +26,10 @@ ifeq ($(PARLOOPER_COMPILER),icc)
   CXXFLAGS := -fopenmp -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++14 -O2 
 endif
 LDFLAGS = -ldl 
-IFLAGS = -I../../include -I../../utils -I$(LIBXSMM_ROOT)/include -I$(LIBXSMM_DNN_ROOT)/include
-SRCDIRS = ../../utils ../../src .
-SRCFILES := par_loop_generator.cpp jit_compile.cpp common_loops.cpp spgemm.cpp
-OBJFILES := $(patsubst %,$(BLDDIR)/%,$(notdir $(SRCFILES:.cpp=-cpp.o)))
+IFLAGS = -I$(PARLOOPER_ROOT)/include -I$(PARLOOPER_ROOT)/utils -I$(LIBXSMM_ROOT)/include -I$(LIBXSMM_DNN_ROOT)/include
+SRCDIRS = $(PARLOOPER_ROOT)/utils $(PARLOOPER_ROOT)/src .
+#SRCFILES := par_loop_generator.cpp jit_compile.cpp common_loops.cpp spgemm.cpp
+#OBJFILES := $(patsubst %,$(BLDDIR)/%,$(notdir $(SRCFILES:.cpp=-cpp.o)))
 XFILES := $(OUTDIR)/spgemm 
 vpath %.cpp $(SRCDIRS) 
 
@@ -37,13 +39,12 @@ all: $(XFILES) CLEANOBJ
 $(BLDDIR)/%-cpp.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -c $< -o $@
 
-$(OUTDIR)/spgemm: $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/spgemm-cpp.o
-	$(CXX) $(BLDDIR)/par_loop_generator-cpp.o $(BLDDIR)/jit_compile-cpp.o $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/spgemm-cpp.o $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o spgemm
+$(OUTDIR)/spgemm: $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/spgemm-cpp.o
+	$(CXX) $(BLDDIR)/common_loops-cpp.o  $(BLDDIR)/spgemm-cpp.o $(PARLOOPER_ROOT)/lib/libparlooper.a $(LIBXSMM_ROOT)/lib/libxsmm.a $(LIBXSMM_ROOT)/lib/libxsmmnoblas.a $(CXXFLAGS) $(IFLAGS) $(LFLAGS) $(LDFLAGS) -o spgemm
 
 CLEANOBJ:
-	rm -rf *.o
+	rm -f *.o $(BLD_DIR)/*.o
 
 .PHONY: clean
-clean:
-	rm -rf spgemm *.o
-
+clean: CLEANOBJ
+	rm -f $(XFILES)


### PR DESCRIPTION
- Added a makefile for building static and dynamic parlooper libs
- Modified samples makefiles to link statically to the parlooper lib (and also so that it can be built outside the sample/ directory)

Checked that the new Makefiles work. Additionally checked with the conv sample that linking to the dynamic libs work fine. 